### PR TITLE
Allow unprivileged 'make install' to succeed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,8 +23,16 @@ EXTRA_DIST = README.md VERSION $(tal_DATA)
 
 install-data-hook:
 	-@if [ ! -d "$(DESTDIR)$(RPKI_BASE_DIR)" ]; then \
-		$(INSTALL) -m 755 -o $(RPKI_USER) -d "$(DESTDIR)$(RPKI_BASE_DIR)"; \
+		if [ "`id -u`" = "0" ]; then \
+			$(INSTALL) -m 755 -o $(RPKI_USER) -d "$(DESTDIR)$(RPKI_BASE_DIR)"; \
+		else \
+			$(INSTALL) -m 755 -d "$(DESTDIR)$(RPKI_BASE_DIR)"; \
+		fi \
 	fi
 	-@if [ ! -d "$(DESTDIR)$(RPKI_OUT_DIR)" ]; then \
-		$(INSTALL) -m 755 -o $(RPKI_USER) -d "$(DESTDIR)$(RPKI_OUT_DIR)"; \
+		if [ "`id -u`" = "0" ]; then \
+			$(INSTALL) -m 755 -o $(RPKI_USER) -d "$(DESTDIR)$(RPKI_OUT_DIR)"; \
+		else \
+			$(INSTALL) -m 755 -d "$(DESTDIR)$(RPKI_OUT_DIR)"; \
+		fi \
 	fi

--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,8 @@ install-data-hook:
 			$(INSTALL) -m 755 -o $(RPKI_USER) -d "$(DESTDIR)$(RPKI_BASE_DIR)"; \
 		else \
 			$(INSTALL) -m 755 -d "$(DESTDIR)$(RPKI_BASE_DIR)"; \
+			echo "Warning: Unprivileged permissions, remember to run" \
+				"'chown $(RPKI_USER) $(DESTDIR)$(RPKI_BASE_DIR)'"; \
 		fi \
 	fi
 	-@if [ ! -d "$(DESTDIR)$(RPKI_OUT_DIR)" ]; then \
@@ -34,5 +36,7 @@ install-data-hook:
 			$(INSTALL) -m 755 -o $(RPKI_USER) -d "$(DESTDIR)$(RPKI_OUT_DIR)"; \
 		else \
 			$(INSTALL) -m 755 -d "$(DESTDIR)$(RPKI_OUT_DIR)"; \
+			echo "Warning: Unprivileged permissions, remember to run" \
+				"'chown $(RPKI_USER) $(DESTDIR)$(RPKI_OUT_DIR)'"; \
 		fi \
 	fi


### PR DESCRIPTION
Fedora builds/installs are always unprivileged and the final permissions are handled by some RPM "magic", thus without this patch I'm ending up with the following errors and no created directories.
```
/usr/bin/install: invalid user 'rpki-client'
make[3]: [Makefile:873: install-data-hook] Error 1 (ignored)
/usr/bin/install: invalid user 'rpki-client'
make[3]: [Makefile:874: install-data-hook] Error 1 (ignored)
```
Let me know if the patch needs to be improved or rewritten.