### PR TITLE
Avoid double $(DESTDIR) during 'make install'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@
 SUBDIRS = include compat src
 ACLOCAL_AMFLAGS = -I m4
 
-taldir = $(DESTDIR)$(RPKI_TAL_DIR)
+taldir = $(RPKI_TAL_DIR)
 tal_DATA = afrinic.tal apnic.tal lacnic.tal ripe.tal
 
 EXTRA_DIST = README.md VERSION $(tal_DATA)


### PR DESCRIPTION
Without this patch I'm ending up with $(DESTDIR) twice, which doesn't feel right.
```
/usr/bin/mkdir -p '/builddir/build/BUILDROOT/rpki-client-0.3.0-2.fc33.x86_64/builddir/build/BUILDROOT/rpki-client-0.3.0-2.fc33.x86_64/etc/pki/tals'
/usr/bin/install -p -m 644 afrinic.tal apnic.tal lacnic.tal ripe.tal '/builddir/build/BUILDROOT/rpki-client-0.3.0-2.fc33.x86_64/builddir/build/BUILDROOT/rpki-client-0.3.0-2.fc33.x86_64/etc/pki/tals'
```