### PR TITLE
Fail './configure' if OpenSSL libraries or headers are missing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -114,7 +114,10 @@ AM_CONDITIONAL([HAVE_UNVEIL], [test "x$ac_cv_func_unveil" = xyes])
 
 AC_CHECK_HEADERS([err.h sha2.h])
 
-AC_CHECK_HEADERS([openssl/cms.h openssl/err.h openssl/evp.h openssl/ssl.h openssl/x509.h openssl/x509v3.h])
+AC_CHECK_LIB([crypto], [ASN1_STRING_get0_data], [], [AC_MSG_ERROR([OpenSSL libraries required])])
+AC_CHECK_HEADERS([openssl/cms.h openssl/err.h openssl/evp.h openssl/ssl.h openssl/x509.h openssl/x509v3.h],
+	[], [AC_MSG_ERROR([OpenSSL headers required])]
+)
 
 AC_ARG_WITH([user],
 	AS_HELP_STRING([--with-user=user],


### PR DESCRIPTION
Without this patch, `./configure` nicely tells about non-existing OpenSSL headers, but doesn't fail – it obviously fails later during `make` then. The library check catches OpenSSL >= 1.1.0, because the header check also matches on OpenSSL < 1.1.0 (and fails during `make`).