### PR TITLE
openssl/*.h: accepted by the compiler, rejected by the preprocessor!

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -114,10 +114,13 @@ AM_CONDITIONAL([HAVE_UNVEIL], [test "x$ac_cv_func_unveil" = xyes])
 
 AC_CHECK_HEADERS([err.h sha2.h])
 
+save_cppflags="$CPPFLAGS"
+CPPFLAGS="$CFLAGS"
 AC_CHECK_LIB([crypto], [ASN1_STRING_get0_data], [], [AC_MSG_ERROR([OpenSSL libraries required])])
 AC_CHECK_HEADERS([openssl/cms.h openssl/err.h openssl/evp.h openssl/ssl.h openssl/x509.h openssl/x509v3.h],
 	[], [AC_MSG_ERROR([OpenSSL headers required])]
 )
+CPPFLAGS="$save_cppflags"
 
 AC_ARG_WITH([user],
 	AS_HELP_STRING([--with-user=user],

--- a/configure.ac
+++ b/configure.ac
@@ -114,7 +114,10 @@ AM_CONDITIONAL([HAVE_UNVEIL], [test "x$ac_cv_func_unveil" = xyes])
 
 AC_CHECK_HEADERS([err.h sha2.h])
 
-AC_CHECK_HEADERS([openssl/cms.h openssl/err.h openssl/evp.h openssl/ssl.h openssl/x509.h openssl/x509v3.h])
+AC_CHECK_LIB([crypto], [ASN1_STRING_get0_data], [], [AC_MSG_ERROR([OpenSSL libraries required])])
+AC_CHECK_HEADERS([openssl/cms.h openssl/err.h openssl/evp.h openssl/ssl.h openssl/x509.h openssl/x509v3.h],
+	[], [AC_MSG_ERROR([OpenSSL headers required])]
+)
 
 AC_ARG_WITH([user],
 	AS_HELP_STRING([--with-user=user],


### PR DESCRIPTION
RHEL/CentOS 7 doesn't ship OpenSSL 1.1 by default, thus I need to supply different build-time parameters:
```
export CFLAGS="$RPM_OPT_FLAGS $(pkg-config --cflags openssl11)"
export LDFLAGS="$RPM_LD_FLAGS $(pkg-config --libs openssl11)"
./configure …
```
This however leads to these warnings:
```
checking openssl/cms.h usability... yes
checking openssl/cms.h presence... no
checking for openssl/cms.h... configure: WARNING: openssl/cms.h: accepted by the compiler, rejected by the preprocessor!
configure: WARNING: openssl/cms.h: proceeding with the compiler's result
yes
checking openssl/err.h usability... yes
checking openssl/err.h presence... no
checking for openssl/err.h... configure: WARNING: openssl/err.h: accepted by the compiler, rejected by the preprocessor!
configure: WARNING: openssl/err.h: proceeding with the compiler's result
yes
checking openssl/evp.h usability... yes
checking openssl/evp.h presence... no
checking for openssl/evp.h... configure: WARNING: openssl/evp.h: accepted by the compiler, rejected by the preprocessor!
configure: WARNING: openssl/evp.h: proceeding with the compiler's result
yes
checking openssl/ssl.h usability... yes
checking openssl/ssl.h presence... no
checking for openssl/ssl.h... configure: WARNING: openssl/ssl.h: accepted by the compiler, rejected by the preprocessor!
configure: WARNING: openssl/ssl.h: proceeding with the compiler's result
yes
checking openssl/x509.h usability... yes
checking openssl/x509.h presence... no
checking for openssl/x509.h... configure: WARNING: openssl/x509.h: accepted by the compiler, rejected by the preprocessor!
configure: WARNING: openssl/x509.h: proceeding with the compiler's result
yes
checking openssl/x509v3.h usability... yes
checking openssl/x509v3.h presence... no
checking for openssl/x509v3.h... configure: WARNING: openssl/x509v3.h: accepted by the compiler, rejected by the preprocessor!
configure: WARNING: openssl/x509v3.h: proceeding with the compiler's result
yes
```
I guess this PR is not a good style, but it makes it disappearing. Maybe somebody could provide a better replacement or a better suggestion?
