### PR TITLE
Limit 'git <action>' to 'openbsd/.git' existence

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -13,10 +13,12 @@ if [ ! -d openbsd ]; then
 		git clone "${RPKICLIENT_GIT}/openbsd"
 	fi
 fi
-(cd openbsd/src
- git fetch
- git checkout "${openbsd_branch}"
- git pull --rebase)
+if [ -d openbsd/.git ]; then
+	(cd openbsd/src
+	 git fetch
+	 git checkout "${openbsd_branch}"
+	 git pull --rebase)
+fi
 
 # setup source paths
 dir=`pwd`


### PR DESCRIPTION
This small hack ensures that `git <action>` in `update.sh` only happens if `openbsd/.git` exists. It should not have any impact on regular operations, however it allows to build reproducible snapshots (if there is no release tarball) in offline build environments by filling the `openbsd` directory with a pre-defined checkout (rather depending on an internet connection for `autogen.sh` and maybe changing commits in the upstream VCS).