### PR TITLE
adding autogen.sh (first build step)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ At the time of writing the Portable version is known to build and work on:
 Building
 --------
 
+    $ ./autogen.sh
     $ ./configure
     $ make
 


### PR DESCRIPTION
To be able to run `./configure`, we need to generate this file first.