### PR TITLE
Link against -lfts if needed (when using musl libc)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,8 @@ AC_CHECK_FUNCS([pledge unveil])
 # Share test results with automake
 AC_SEARCH_LIBS([__b64_pton],[resolv])
 AC_CHECK_FUNCS([__b64_pton])
+AC_SEARCH_LIBS([fts_open],[fts])
+AC_CHECK_FUNCS([fts_open])
 
 AM_CONDITIONAL([HAVE_REALLOCARRAY], [test "x$ac_cv_func_reallocarray" = xyes])
 AM_CONDITIONAL([HAVE_RECALLOCARRAY], [test "x$ac_cv_func_recallocarray" = xyes])


### PR DESCRIPTION
With https://github.com/rpki-client/rpki-client-openbsd/commit/fbc33757884fada818c04cd542123c809f867a52 the dependency to `fts_open()` was introduced which is not part of musl libc (Alpine Linux), but in a separate `libfts.so`. Without this patch, the build-time failure looks like this:

```
/usr/lib/gcc/x86_64-alpine-linux-musl/9.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: rpki_client-main.o: in function `repo_cleanup':
/tmp/rpki-client-portable/src/main.c:1307: undefined reference to `fts_open'
/usr/lib/gcc/x86_64-alpine-linux-musl/9.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /tmp/rpki-client-portable/src/main.c:1311: undefined reference to `fts_read'
/usr/lib/gcc/x86_64-alpine-linux-musl/9.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /tmp/rpki-client-portable/src/main.c:1311: undefined reference to `fts_read'
/usr/lib/gcc/x86_64-alpine-linux-musl/9.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /tmp/rpki-client-portable/src/main.c:1342: undefined reference to `fts_close'
```