### PR TITLE
Add a run of rpki-client in our CI build to see if the build works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,6 @@ script:
   ./autogen.sh;
   ./configure;
   make -k;
-  make distcheck
+  make distcheck;
+  mkdir rpki-cache rpki;
+  src/rpki-client -v -t afrinic.tal -t apnic.tal -t lacnic.tal -t ripe.tal -d rpki-cache rpki


### PR DESCRIPTION
This runs rpki-client -v at the end of the travis CI build to verify that the resulting binary works (this assumes that rpki-client only exits 0 if no error happened). As usual ARIN is not tested but that's their fault.
This increases the build time by 4 minutes.

Should we add something like this?
It would be possible to run it against a small repo (exclude ripe.tal and apnic.tal) or build our own test repo that way the output could be validated as well.