### PR TITLE
Sync a_time_tm.c with OpenBSD CVS

### DIFF
--- a/compat/a_time_tm.c
+++ b/compat/a_time_tm.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: a_time_tm.c,v 1.15 2018/04/25 11:48:21 tb Exp $ */
+/* $OpenBSD: a_time_tm.c,v 1.17 2020/12/16 18:46:29 tb Exp $ */
 /*
  * Copyright (c) 2015 Bob Beck <beck@openbsd.org>
  *
@@ -93,10 +93,9 @@ ASN1_time_parse(const char *bytes, size_t len, struct tm *tm, int mode)
 		return (-1);
 
 	lt = tm;
-	if (lt == NULL) {
-		memset(&ltm, 0, sizeof(ltm));
+	if (lt == NULL)
 		lt = &ltm;
-	}
+	memset(lt, 0, sizeof(*lt));
 
 	/* Timezone is required and must be GMT (Zulu). */
 	if (bytes[len - 1] != 'Z')


### PR DESCRIPTION
The bugfix is not relevant for rpki-client, but let's try to keep this
copy in sync.