### PR TITLE
Add sys/wait.h to noinst_HEADERS (for Alpine Linux)

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -3,6 +3,7 @@ noinst_HEADERS += sys/_null.h
 noinst_HEADERS += sys/queue.h
 noinst_HEADERS += sys/tree.h
 noinst_HEADERS += sys/types.h
+noinst_HEADERS += sys/wait.h
 noinst_HEADERS += openssl/asn1.h
 noinst_HEADERS += imsg.h
 noinst_HEADERS += poll.h


### PR DESCRIPTION
Without this patch, `sys/wait.h` doesn't make it into the rpki-client release tarball and thus building on Alpine Linux fails like this:

```
main.c: In function 'main':
main.c:1049:17: error: 'WAIT_ANY' undeclared (first use in this function)
 1049 |   pid = waitpid(WAIT_ANY, &st, 0);
      |                 ^~~~~~~~
main.c:1049:17: note: each undeclared identifier is reported only once for each function it appears in
```