### PR TITLE
Fix broken build: Add new source file from project rpki-client/rpli-client-openbsd

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -58,6 +58,7 @@ rpki_client_SOURCES += rrdp.c
 rpki_client_SOURCES += rrdp_delta.c
 rpki_client_SOURCES += rrdp_notification.c
 rpki_client_SOURCES += rrdp_snapshot.c
+rpki_client_SOURCES += rrdp_util.c
 rpki_client_SOURCES += rsync.c
 rpki_client_SOURCES += tal.c
 rpki_client_SOURCES += validate.c

--- a/update.sh
+++ b/update.sh
@@ -62,7 +62,7 @@ ${CP} "${libutil_src}/imsg-buffer.c" compat/
 for i in as.c cert.c cms.c crl.c encoding.c extern.h gbr.c http.c io.c ip.c \
 	log.c main.c mft.c mkdir.c output-bgpd.c output-bird.c output-csv.c \
 	output-json.c output.c parser.c repo.c roa.c rpki-client.8 rrdp.c \
-	rrdp.h rrdp_delta.c rrdp_notification.c rrdp_snapshot.c rsync.c \
+	rrdp.h rrdp_delta.c rrdp_notification.c rrdp_snapshot.c rrdp_util.c rsync.c \
 	tal.c validate.c version.h x509.c; do
 	file=`basename ${i}`
 	echo Copying ${file}


### PR DESCRIPTION
The current build is **broken**. 

```
#9 10.00 /usr/bin/sed \
#9 10.00 	-e 's|@RPKI_TAL_DIR[@]|/usr/local/etc/rpki|g' \
#9 10.00 	-e 's|@RPKI_BASE_DIR[@]|/usr/local/var/cache/rpki-client|g' \
#9 10.00 	-e 's|@RPKI_OUT_DIR[@]|/usr/local/var/db/rpki-client|g' \
#9 10.00 	-e 's|@RSYNC[@]|rsync|g' \
#9 10.00 	'./rpki-client.8.in' >rpki-client.8
#9 10.01   CCLD     rpki-client
#9 10.24 /usr/bin/ld: rpki_client-rrdp_delta.o: in function `delta_content_handler':
#9 10.24 /root/rpki-client-portable-7.5/src/rrdp_delta.c:224: undefined reference to `publish_add_content'
#9 10.24 /usr/bin/ld: rpki_client-rrdp_delta.o: in function `start_publish_withdraw_elem':
#9 10.24 /root/rpki-client-portable-7.5/src/rrdp_delta.c:151: undefined reference to `new_publish_xml'
#9 10.24 /usr/bin/ld: rpki_client-rrdp_delta.o: in function `end_publish_withdraw_elem':
#9 10.24 /root/rpki-client-portable-7.5/src/rrdp_delta.c:165: undefined reference to `publish_done'
#9 10.24 /usr/bin/ld: rpki_client-rrdp_delta.o: in function `free_delta_xml':
#9 10.24 /root/rpki-client-portable-7.5/src/rrdp_delta.c:268: undefined reference to `free_publish_xml'
#9 10.24 /usr/bin/ld: rpki_client-rrdp_snapshot.o: in function `snapshot_content_handler':
#9 10.24 /root/rpki-client-portable-7.5/src/rrdp_snapshot.c:200: undefined reference to `publish_add_content'
#9 10.24 /usr/bin/ld: rpki_client-rrdp_snapshot.o: in function `start_publish_elem':
#9 10.24 /root/rpki-client-portable-7.5/src/rrdp_snapshot.c:136: undefined reference to `new_publish_xml'
#9 10.24 /usr/bin/ld: rpki_client-rrdp_snapshot.o: in function `end_publish_elem':
#9 10.24 /root/rpki-client-portable-7.5/src/rrdp_snapshot.c:149: undefined reference to `publish_done'
#9 10.24 /usr/bin/ld: rpki_client-rrdp_snapshot.o: in function `free_snapshot_xml':
#9 10.24 /root/rpki-client-portable-7.5/src/rrdp_snapshot.c:245: undefined reference to `free_publish_xml'
#9 10.24 collect2: error: ld returned 1 exit status
#9 10.25 make[1]: *** [Makefile:498: rpki-client] Fehler 1
#9 10.25 make[1]: Verzeichnis „/root/rpki-client-portable-7.5/src“ wird verlassen
#9 10.25 make: *** [Makefile:458: all-recursive] Fehler 1
```

**Reason:**

The script _/update.sh_ clones the repository _rpki-client/rpli-client-openbsd_, which had [a recent refactoring commit](https://github.com/rpki-client/rpki-client-openbsd/commit/8d046365005e3075f7d4930729ef79ce873936ba#diff-2e603df007bcbae358e31aa3c13e4c437c6700cdf783394b11f71960e58e7a7d). Some functions were extracted into a separate source file.

**Solution:**

I added the new file name at two places to make the build work again.

**Still unfixed:**

We build the rpki-client 7.5 using [the tagged tarball](https://www.rpki-client.org/portable.html), assuming that it'll be a stable release.<br>
However, it is not.<br>
The mentioned _/update.sh_ script will clone additional project sources from gihub, but it fails to do so based on a [dedicated version tag](https://github.com/rpki-client/rpki-client-openbsd/releases/tag/rpki-client-7.5). This way the build procedure is bound to stumble, whenever there's some non-trivial changes over there.


