### PR TITLE
Update working Linux distributions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -89,8 +89,9 @@ CFLAGS="-O2 " LDFLAGS="-s" ./configure
 Rpki-client is available as pre-built package for many distributions: https://repology.org/project/rpki-client
 
 Alpine: apk add rpki-client
-CentOS/Fedora/Redhat: yum install rpki-client (via EPEL)
+CentOS/RHEL/Rocky: yum install epel-release; yum install rpki-client
 Debian/Ubuntu: apt install rpki-client
+Fedora: dnf install rpki-client
 FreeBSD: pkg install rpki-client
 macOSX: port install rpki-client || brew install rpki-client
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Platform Requirements
 At the time of writing the portable version is known to build and work on:
 
  - OpenBSD
- - Alpine 3.14
- - CentOS/RHEL/Rocky 7, 8
+ - Alpine 3.15
+ - CentOS/RHEL/Rocky 7, 8, 9
  - Debian 9, 10
- - Fedora 33, 34, 35
+ - Fedora 34, 35, 36, 37
  - Ubuntu 20.04 LTS, 21.04
  - FreeBSD 12 and 13
  - macOS Catalina


### PR DESCRIPTION
  * There is no EPEL for Fedora, just for CentOS/RHEL/Rocky
  * Fedora prefers `dnf` over `yum` meanwhile (it's just a symlink)
  * Our Docker/Quay containers are already built using Alpine 3.15
  * RHEL 9 is around the corner (and EPEL 9 builds are working fine)
  * Fedora 33 is EOL, Fedora 36 is around the corner, 37 is next