### PR TITLE
Document correct minimum OpenSSL version

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -2,7 +2,7 @@
 ----------------
 
 You will need the following libraries:
- - libcrypto: LibreSSL (3.5.0 or newer) or OpenSSL (1.0.2e or newer).
+ - libcrypto: LibreSSL (3.5.0 or newer) or OpenSSL (1.1.0a or newer).
  - libtls: LibreSSL or libretls
  - libexpat
 


### PR DESCRIPTION
`X509_up_ref()` appeared for the first time with OpenSSL 1.1.0-pre1, and `ASN1_STRING_get0_data()` appeared for the first time with OpenSSL 1.1.0a.

See also:

 - https://github.com/openssl/openssl/commit/05f0fb9f6acc34c82a082d7668572828925694e7
 - https://github.com/openssl/openssl/commit/17ebf85abda18c3875b1ba6670fe7b393bc1f297
 - https://github.com/rpki-client/rpki-client-portable/pull/7#issuecomment-615986414