### PR TITLE
check for fts.h availability

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -264,6 +264,7 @@ if test "x$ac_cv_func_inet_net_pton" = "xyes"; then
 fi
 
 # check functions that may be in different libs on other systems
+AC_CHECK_HEADERS([fts.h], [], [AC_MSG_ERROR([fts.h is required])])
 AC_SEARCH_LIBS([fts_open],[fts])
 AC_CHECK_FUNCS([fts_open])
 


### PR DESCRIPTION
the configure script checks for fts functions and if found, adds the -lfts to the generated makefiles but `fts.h` is directly included without any guards and the rest of the code does use `fts_*` functions, rendering the test useless.

in systems like musl hosts where an external fts implementation needs to be brought in, this causes the following error:
```c
repo.c:28:10: fatal error: 'fts.h' file not found
#include <fts.h>
```
on musl hosts the error can be prevented by building and linking against [musl-fts](https://github.com/void-linux/musl-fts) but the configure script should die if fts.h is not present during the configuration stage in order to prevent surprises:
```sh
checking for fts.h... no
configure: error: fts.h is required
```