### PR TITLE
Add compat shim for X509_get0_uids()

### DIFF
--- a/compat/Makefile.am
+++ b/compat/Makefile.am
@@ -110,6 +110,10 @@ if !HAVE_X509_GET_EXTENSION_FLAGS
 libcompat_la_SOURCES += x509_purp.c
 endif
 
+if !HAVE_X509_GET0_UIDS
+libcompat_la_SOURCES += x509_get0_uids.c
+endif
+
 if !HAVE_PLEDGE
 libcompat_la_SOURCES += pledge.c
 endif

--- a/compat/x509_get0_uids.c
+++ b/compat/x509_get0_uids.c
@@ -1,0 +1,16 @@
+/*
+ * X509_get0_uids compatibility shim. Public domain.
+ */
+
+#include <openssl/asn1.h>
+#include <openssl/x509.h>
+
+void
+X509_get0_uids(const X509 *x, const ASN1_BIT_STRING **issuerUID,
+    const ASN1_BIT_STRING **subjectUID)
+{
+	if (issuerUID != NULL)
+		*issuerUID = NULL;
+	if (subjectUID != NULL)
+		*subjectUID = NULL;
+}

--- a/configure.ac
+++ b/configure.ac
@@ -320,10 +320,11 @@ AC_CHECK_FUNCS([tls_default_ca_cert_file tls_config_set_ca_mem], [], [AC_MSG_ERR
 
 # check for libressl special functions after including libtls in case
 # these are present in that library
-AC_CHECK_FUNCS([ASN1_time_parse ASN1_time_tm_cmp X509_get_extension_flags])
+AC_CHECK_FUNCS([ASN1_time_parse ASN1_time_tm_cmp X509_get_extension_flags X509_get0_uids])
 AM_CONDITIONAL([HAVE_ASN1_TIME_PARSE], [test "x$ac_cv_func_ASN1_time_parse" = xyes])
 AM_CONDITIONAL([HAVE_ASN1_TIME_TM_CMP], [test "x$ac_cv_func_ASN1_time_tm_cmp" = xyes])
 AM_CONDITIONAL([HAVE_X509_GET_EXTENSION_FLAGS], [test "x$ac_cv_func_X509_get_extension_flags" = xyes])
+AM_CONDITIONAL([HAVE_X509_GET0_UIDS], [test "x$ac_cv_func_X509_get0_uids" = xyes])
 
 AC_CHECK_HEADERS([expat.h], [], [AC_MSG_ERROR([Expat headers required])])
 AC_CHECK_LIB([expat], [XML_Parse], [], [AC_MSG_ERROR([Expat library required])])

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -1,0 +1,16 @@
+
+/*
+ * Public domain
+ * openssl/x509.h compatibility shim
+ */
+
+#include_next <openssl/x509.h>
+
+#ifndef LIBCOMPAT_OPENSSL_X509_H
+#define LIBCOMPAT_OPENSSL_X509_H
+
+#ifndef HAVE_X509_GET0_UIDS
+void X509_get0_uids(const X509 *x, const ASN1_BIT_STRING **issuerUID,
+    const ASN1_BIT_STRING **subjectUID);
+#endif
+#endif


### PR DESCRIPTION
LibreSSL < 3.7.2 doesn't support this. This allows us to use this function for a correctness check OpenBSD without needing to bump the minimum LibreSSL requirement.