### PR TITLE
Update build harness for log.c removal

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -46,7 +46,6 @@ rpki_client_SOURCES += http.c
 rpki_client_SOURCES += io.c
 rpki_client_SOURCES += ip.c
 rpki_client_SOURCES += json.c
-rpki_client_SOURCES += log.c
 rpki_client_SOURCES += main.c
 rpki_client_SOURCES += mft.c
 rpki_client_SOURCES += mkdir.c

--- a/update.sh
+++ b/update.sh
@@ -61,7 +61,7 @@ ${CP} "${libutil_src}/imsg-buffer.c" compat/
 (cd compat; ${PATCH} -p0 < "${patches}/patch-imsg.c")
 
 for i in as.c aspa.c cert.c cms.c crl.c encoding.c extern.h filemode.c \
-	gbr.c geofeed.c http.c io.c ip.c json.c json.h log.c main.c mft.c \
+	gbr.c geofeed.c http.c io.c ip.c json.c json.h main.c mft.c \
 	mkdir.c ometric.c ometric.h output-bgpd.c output-bird.c output-csv.c \
 	output-json.c output-ometric.c output.c parser.c print.c \
 	repo.c roa.c rpki-client.8 rrdp.c rrdp.h rrdp_delta.c \


### PR DESCRIPTION
This will build after the next sync from OpenBSD.