### PR TITLE
Allow actually disabling landlock support.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -378,8 +378,8 @@ if test "x$enable_landlock" = "xyes"; then
 	if test "x$ac_cv_header_linux_landlock_h" = xyes; then
 		AC_DEFINE([HAVE_LANDLOCK])
 	fi
-	AM_CONDITIONAL([HAVE_LANDLOCK], [test "x$ac_cv_header_linux_landlock_h" = xyes])
 fi
+AM_CONDITIONAL([HAVE_LANDLOCK], [test "x$ac_cv_header_linux_landlock_h" = xyes])
 
 AC_ARG_WITH([user],
 	AS_HELP_STRING([--with-user=user],


### PR DESCRIPTION
Fixes undefined macro HAVE_LANDLOCK when --disable-landlock is passed.