### PR TITLE
Bump GitHub actions/checkout from 3 to 4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
           - os: macos-latest
             compiler: gcc-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: install macOS autogen prerequisites
         run: brew install autoconf automake libtool
         if: runner.os == 'macOS'

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -22,7 +22,7 @@ jobs:
         language: [ 'cpp' ]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: install missing deps
       run: sudo apt-get install libtls-dev
     - name: Initialize CodeQL


### PR DESCRIPTION
Main change is an update of the default runtime to Node 20 inside the action.

Note: I've added `actions/checkout@v4,` to https://github.com/rpki-client/rpki-client-portable/settings/actions (after it failed).