### PR TITLE
Add -D_OPENBSD_SOURCE to netbsd compile flags to handle strtonum.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,7 @@ char buf[1]; getentropy(buf, 1);
 		;;
 	*netbsd*)
 		HOST_OS=netbsd
+		CFLAGS="$CFLAGS -D_OPENBSD_SOURCE"
 		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <sys/param.h>
 #if __NetBSD_Version__ < 700000001


### PR DESCRIPTION
Same fix as I committed to openbgpd-portable. NetBSD has to be a special snowflake.