### PR TITLE
Update to CodeQL Action v3

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: install missing deps
       run: sudo apt-get install libtls-dev
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
     - name: Build Application using script
@@ -35,6 +35,6 @@ jobs:
         ./configure
         make
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
See also: https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/