### PR TITLE
Define `stat.st_mtim` for macOS and NetBSD (fixes #122)

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -3,6 +3,7 @@ noinst_HEADERS += arpa/inet.h
 noinst_HEADERS += sys/_null.h
 noinst_HEADERS += sys/queue.h
 noinst_HEADERS += sys/socket.h
+noinst_HEADERS += sys/stat.h
 noinst_HEADERS += sys/time.h
 noinst_HEADERS += sys/tree.h
 noinst_HEADERS += sys/types.h

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -1,0 +1,15 @@
+/*
+ * Public domain
+ * sys/stat.h compatibility shim
+ */
+
+#include_next <sys/stat.h>
+
+#ifndef LIBCOMPAT_SYS_STAT_H
+#define LIBCOMPAT_SYS_STAT_H
+
+#if defined(__APPLE__) || defined(__NetBSD__)
+#define st_mtim st_mtimespec
+#endif
+
+#endif


### PR DESCRIPTION
```
repo.c:684:17: error: no member named 'st_mtim' in 'struct stat'
        rr->mtime = st.st_mtim.tv_sec;
                    ~~ ^
```

See also: https://github.com/hboetes/mg/issues/7#issuecomment-475869095