### PR TITLE
Switch gcc-12 to gcc-14, default is gcc-13

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        compiler: [cc, clang, gcc-12]
+        compiler: [cc, clang, gcc-14]
         os: [ubuntu-latest, macos-latest]
         exclude:
           - os: macos-latest
             compiler: cc
           - os: macos-latest
-            compiler: gcc-12
+            compiler: gcc-14
     steps:
       - uses: actions/checkout@v4
       - name: install macOS autogen prerequisites


### PR DESCRIPTION
It makes more sense to test building using a more than less recent compiler. Unfortunately, Ubuntu 24.04 LTS doesn't provide GCC 15 (yet?).