### PR TITLE
GHA: improvements suggested by zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
           - os: macos-latest
             compiler: gcc-14
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: install macOS autogen prerequisites

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,8 @@ jobs:
             compiler: gcc-14
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: install macOS autogen prerequisites
         run: brew install autoconf automake libtool
         if: runner.os == 'macOS'

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: install missing deps
       run: |
         sudo apt-get update

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -22,7 +22,7 @@ jobs:
         language: [ 'cpp' ]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: install missing deps

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -30,7 +30,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install libtls-dev
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
       with:
         languages: ${{ matrix.language }}
     - name: Build Application using script
@@ -39,6 +39,6 @@ jobs:
         ./configure
         make
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 #v4.35.1
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: "Install dependencies"
         run: |

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   scan:
     name: "Scan"
+    environment: "coverity"
     runs-on: "ubuntu-24.04"
     if: ${{ github.repository_owner == 'rpki-client' || github.event_name == 'workflow_dispatch' }}
     permissions:


### PR DESCRIPTION
This allows pinning down a few things a bit more in our repo and appeases zizmor apart from

```
warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/build.yaml:12:3
```

about which I'm unsure.

Of course this requires some fiddling with the repo settings to be beneficial. It's all such a pain...