### PR TITLE
OpenSSL 4 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -468,7 +468,11 @@ AC_CHECK_FUNCS([tls_default_ca_cert_file tls_config_set_ca_mem], [], [AC_MSG_ERR
 
 # check for libressl special functions after including libtls in case
 # these are present in that library
+AC_CHECK_FUNCS([ASN1_BIT_STRING_get_length ASN1_BIT_STRING_set1])
 AC_CHECK_FUNCS([CMS_get_version X509_get0_uids X509_CRL_get0_tbs_sigalg])
+# available since OpenSSL 4 and LibreSSL 4.4
+AM_CONDITIONAL([HAVE_ASN1_BIT_STRING_GET_LENGTH], [test "x$ac_cv_func_ASN1_BIT_STRING_get_length" = xyes])
+AM_CONDITIONAL([HAVE_ASN1_BIT_STRING_SET1], [test "x$ac_cv_func_ASN1_BIT_STRING_set1" = xyes])
 # available since LibreSSL 3.8.1
 AM_CONDITIONAL([HAVE_CMS_GET_VERSION], [test "x$ac_cv_func_CMS_get_version" = xyes])
 # available since LibreSSL 3.7.1

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,6 +34,7 @@ rpki_client_LDADD += $(top_builddir)/compat/libcompat.la
 rpki_client_LDADD += $(top_builddir)/compat/libcompatnoopt.la
 
 rpki_client_SOURCES = as.c
+rpki_client_SOURCES += asn1_bit_string.c
 rpki_client_SOURCES += aspa.c
 rpki_client_SOURCES += ccr.c
 rpki_client_SOURCES += cert.c

--- a/update.sh
+++ b/update.sh
@@ -69,8 +69,8 @@ ${CP} "${arc4random_src}"/arc4random_*.h compat
 ${CP} "${libutil_src}/imsg.c" compat/
 ${CP} "${libutil_src}/imsg-buffer.c" compat/
 
-for i in as.c aspa.c ccr.c cert.c cms.c constraints.c crl.c encoding.c \
-	extern.h filemode.c http.c io.c ip.c json.c json.h \
+for i in as.c asn1_bit_string.c aspa.c ccr.c cert.c cms.c constraints.c \
+	crl.c encoding.c extern.h filemode.c http.c io.c ip.c json.c json.h \
 	main.c mft.c mkdir.c ometric.c ometric.h output-bgpd.c output-bird.c \
 	output-csv.c output-json.c output-ometric.c output.c parser.c \
 	print.c repo.c rfc3779.c roa.c rpki-asn1.h rpki-client.8 rrdp.c \


### PR DESCRIPTION
Once asn1_bit_string.c is added to base and src/Makefile.am, this is the bit needed to compile with OpenSSL 4. Of course, this requires a libretls linked against OpenSSL 4, but this is also straightforward.