### PR TITLE
Bump github/codeql-action from 4.37.6 to 4.37.7

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -39,6 +39,6 @@ jobs:
         ./configure
         make
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 #v4.37.6
+      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd #v4.37.7
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -30,7 +30,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install libtls-dev
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       with:
         languages: ${{ matrix.language }}
     - name: Build Application using script


### PR DESCRIPTION
Combine codeql-action updates as they can't be merged separately

Closes: #163
Closes: #164